### PR TITLE
Include the headers in the response for decodable requests

### DIFF
--- a/CBHTTP.xcodeproj/project.pbxproj
+++ b/CBHTTP.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		53D14815A47FF8203ECA1722 /* Pods_CBHTTPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEA6C206306FBFFD4D382958 /* Pods_CBHTTPTests.framework */; };
 		AB3B00322294A9A300F5CFDB /* CBHTTP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E36C67218B62F9005F7DC6 /* CBHTTP.framework */; };
 		AB3B00382294AA9300F5CFDB /* CBHTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E36CA0218B64BF005F7DC6 /* CBHTTPTests.swift */; };
+		D3C8C078229DD7EA00E4238D /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C8C077229DD7EA00E4238D /* HTTPResponse.swift */; };
 		E7779096218C8C4200A9260C /* WebIncomingDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7779095218C8C4200A9260C /* WebIncomingDataType.swift */; };
 		E7779098218C8C9A00A9260C /* WebConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7779097218C8C9A00A9260C /* WebConnectionState.swift */; };
 		E7E36C78218B62F9005F7DC6 /* CBHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E36C6A218B62F9005F7DC6 /* CBHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -48,6 +49,7 @@
 		98CE786C630FB3C25AE16CFA /* Pods-CBHTTP.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CBHTTP.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CBHTTP/Pods-CBHTTP.debug.xcconfig"; sourceTree = "<group>"; };
 		AB3B002D2294A9A300F5CFDB /* CBHTTPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CBHTTPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B747DA8D8D97B6F6D7008DE8 /* Pods_CBHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CBHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3C8C077229DD7EA00E4238D /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		E7779095218C8C4200A9260C /* WebIncomingDataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebIncomingDataType.swift; sourceTree = "<group>"; };
 		E7779097218C8C9A00A9260C /* WebConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebConnectionState.swift; sourceTree = "<group>"; };
 		E7E36C67218B62F9005F7DC6 /* CBHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CBHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -201,6 +203,7 @@
 				E7E36C8F218B6386005F7DC6 /* HTTP.swift */,
 				E7E36C8E218B6386005F7DC6 /* HTTPMethod.swift */,
 				E7E36C8D218B6386005F7DC6 /* HTTPRequest.swift */,
+				D3C8C077229DD7EA00E4238D /* HTTPResponse.swift */,
 				E7E36C90218B6386005F7DC6 /* HTTPService.swift */,
 			);
 			path = HTTP;
@@ -413,6 +416,7 @@
 				E7E36C9C218B6386005F7DC6 /* HTTPMethod.swift in Sources */,
 				E7E36C98218B6386005F7DC6 /* ConnectionStatus.swift in Sources */,
 				E7779098218C8C9A00A9260C /* WebConnectionState.swift in Sources */,
+				D3C8C078229DD7EA00E4238D /* HTTPResponse.swift in Sources */,
 				E7779096218C8C4200A9260C /* WebIncomingDataType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CBHTTP/Extensions/HTTP+Delete.swift
+++ b/CBHTTP/Extensions/HTTP+Delete.swift
@@ -21,7 +21,7 @@ extension HTTP {
         headers: [String: String]? = nil,
         timeout: TimeInterval = HTTP.kDefaultTimeout,
         for responseType: T.Type
-    ) -> Single<T> where T: Decodable {
+    ) -> Single<HTTPResponse<T>> where T: Decodable {
         let request = HTTPRequest<T>(
             service: service,
             method: .delete,

--- a/CBHTTP/Extensions/HTTP+Get.swift
+++ b/CBHTTP/Extensions/HTTP+Get.swift
@@ -21,7 +21,7 @@ extension HTTP {
         headers: [String: String]? = nil,
         timeout: TimeInterval = HTTP.kDefaultTimeout,
         for respType: T.Type
-    ) -> Single<T> where T: Decodable {
+    ) -> Single<HTTPResponse<T>> where T: Decodable {
         let request = HTTPRequest<T>(
             service: service,
             method: .get,

--- a/CBHTTP/Extensions/HTTP+Post.swift
+++ b/CBHTTP/Extensions/HTTP+Post.swift
@@ -21,7 +21,7 @@ extension HTTP {
         headers: [String: String]? = nil,
         timeout: TimeInterval = HTTP.kDefaultTimeout,
         for responseType: T.Type
-    ) -> Single<T> where T: Decodable {
+    ) -> Single<HTTPResponse<T>> where T: Decodable {
         let request = HTTPRequest<T>(
             service: service,
             method: .post,

--- a/CBHTTP/Extensions/HTTP+Put.swift
+++ b/CBHTTP/Extensions/HTTP+Put.swift
@@ -21,7 +21,7 @@ extension HTTP {
         headers: [String: String]? = nil,
         timeout: TimeInterval = HTTP.kDefaultTimeout,
         for responseType: T.Type
-    ) -> Single<T> where T: Decodable {
+    ) -> Single<HTTPResponse<T>> where T: Decodable {
         let request = HTTPRequest<T>(
             service: service,
             method: .put,

--- a/CBHTTP/HTTP/HTTP.swift
+++ b/CBHTTP/HTTP/HTTP.swift
@@ -32,7 +32,7 @@ public struct HTTP {
     ///     - request: An instance of `HTTPRequest` used for API call
     ///
     /// - Returns: An Single for the HTTP request
-    static func makeDecodableRequest<T>(request: HTTPRequest<T>) -> Single<T> {
+    static func makeDecodableRequest<T>(request: HTTPRequest<T>) -> Single<HTTPResponse<T>> {
         guard let responseParser = request.responseParser else {
             return .error(HTTPError.missingResponseParser)
         }
@@ -40,7 +40,9 @@ public struct HTTP {
         return task(for: request).flatMap { result in
             do {
                 let parsed: T = try responseParser(result.data)
-                return .just(parsed)
+                let response = HTTPResponse(headers: result.response.allHeaderFields, body: parsed)
+
+                return .just(response)
             } catch {
                 throw HTTPError.deserializationError(error: error)
             }

--- a/CBHTTP/HTTP/HTTPResponse.swift
+++ b/CBHTTP/HTTP/HTTPResponse.swift
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-2019 Coinbase Inc. See LICENSE
+
+import Foundation
+
+/// The model object returned from HTTP methods
+public struct HTTPResponse<T> {
+    /// HTTP response headers
+    public let headers: [AnyHashable: Any]
+
+    /// Decoded HTTP response body
+    public let body: T
+}

--- a/CBHTTPTests/CBHTTPTests.swift
+++ b/CBHTTPTests/CBHTTPTests.swift
@@ -19,21 +19,24 @@ class CBHTTPTests: XCTestCase {
         let host = HTTPService.identity.url.host!
         let expectedUsername = "satoshi"
         let expectedID = 12345
+        let responseHeaders = ["Content-Type": "application/json"]
 
         stub(condition: isHost(host) && isPath("/user/current")) { request in
             XCTAssertEqual(request.httpMethod, "GET")
             let json: [AnyHashable: Any] = ["id": expectedID, "username": expectedUsername]
-            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: responseHeaders)
         }
 
-        let user = try observable.toBlocking(timeout: unitTestsTimeout).single()
-        XCTAssertEqual(expectedUsername, user.username)
-        XCTAssertEqual(expectedID, user.id)
+        let response = try observable.toBlocking(timeout: unitTestsTimeout).single()
+        XCTAssertEqual(expectedUsername, response.body.username)
+        XCTAssertEqual(expectedID, response.body.id)
+        responseHeaders.forEach { XCTAssertEqual($1, response.headers[$0] as? String) }
     }
 
     func testPostUserRequest() throws {
         let expectedUsername = "biggie"
         let expectedID = 3
+        let responseHeaders = ["Content-Type": "application/json"]
         let params: [String: Any] = ["id": expectedID, "username": expectedUsername]
         let observable = HTTP.post(
             service: .identity,
@@ -55,13 +58,14 @@ class CBHTTPTests: XCTestCase {
 
             let userJSON: [AnyHashable: Any] = ["id": expectedID, "username": expectedUsername]
             let json: [AnyHashable: Any] = ["status": "ok", "user": userJSON]
-            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: responseHeaders)
         }
 
         let response = try observable.toBlocking(timeout: unitTestsTimeout).single()
-        XCTAssertEqual("ok", response.status)
-        XCTAssertEqual(expectedUsername, response.user.username)
-        XCTAssertEqual(expectedID, response.user.id)
+        XCTAssertEqual("ok", response.body.status)
+        XCTAssertEqual(expectedUsername, response.body.user.username)
+        XCTAssertEqual(expectedID, response.body.user.id)
+        responseHeaders.forEach { XCTAssertEqual($1, response.headers[$0] as? String) }
     }
 
     func testGetUserUsingParseClosure() throws {
@@ -112,6 +116,7 @@ class CBHTTPTests: XCTestCase {
     func testDeleteUserRequestUsingDecodable() throws {
         let expectedUsername = "biggie"
         let expectedID = 3
+        let responseHeaders = ["Content-Type": "application/json"]
         let host = HTTPService.identity.url.host!
         let observable = HTTP.delete(service: .identity, path: "/user", timeout: 203, for: MockUser.self)
 
@@ -120,12 +125,13 @@ class CBHTTPTests: XCTestCase {
             XCTAssertEqual(request.timeoutInterval, 203)
 
             let json: [AnyHashable: Any] = ["id": expectedID, "username": expectedUsername]
-            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: responseHeaders)
         }
 
-        let user = try observable.toBlocking(timeout: unitTestsTimeout).single()
-        XCTAssertEqual(expectedUsername, user.username)
-        XCTAssertEqual(expectedID, user.id)
+        let response = try observable.toBlocking(timeout: unitTestsTimeout).single()
+        XCTAssertEqual(expectedUsername, response.body.username)
+        XCTAssertEqual(expectedID, response.body.id)
+        responseHeaders.forEach { XCTAssertEqual($1, response.headers[$0] as? String) }
     }
 
     func testOptionalGetUser() throws {
@@ -133,16 +139,18 @@ class CBHTTPTests: XCTestCase {
         let host = HTTPService.identity.url.host!
         let expectedUsername = "satoshi"
         let expectedID = 12345
+        let responseHeaders = ["Content-Type": "application/json"]
 
         stub(condition: isHost(host) && isPath("/user/current")) { request in
             XCTAssertEqual(request.httpMethod, "GET")
             let json: [AnyHashable: Any] = ["id": expectedID, "username": expectedUsername]
-            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: responseHeaders)
         }
 
-        let user = try observable.toBlocking(timeout: unitTestsTimeout).single()
-        XCTAssertEqual(expectedUsername, user?.username)
-        XCTAssertEqual(expectedID, user?.id)
+        let response = try observable.toBlocking(timeout: unitTestsTimeout).single()
+        XCTAssertEqual(expectedUsername, response.body?.username)
+        XCTAssertEqual(expectedID, response.body?.id)
+        responseHeaders.forEach { XCTAssertEqual($1, response.headers[$0] as? String) }
     }
 }
 


### PR DESCRIPTION
When making a decodable request, include the headers from the response